### PR TITLE
suppress warnings: redundant

### DIFF
--- a/lib/Authen/Simple/LDAP.pm
+++ b/lib/Authen/Simple/LDAP.pm
@@ -93,7 +93,10 @@ sub check {
         return 0;
     }
 
-    $filter = sprintf( $self->filter, ($username) x 10 );
+    {
+        no if ($] >= 5.022), 'warnings' => 'redundant';
+        $filter = sprintf( $self->filter, ($username) x 10 );
+    }
     $search = $connection->search(
         base   => $self->basedn,
         scope  => $self->scope,


### PR DESCRIPTION
From Perl v5.22, `sprintf` with too much argument against `format` is warned as 'Redundant argument in sprintf warnings'.

This pull-request set `no warnings 'redundant'` if Perl version is greater equal v5.22.